### PR TITLE
pcr-calc: Inherit correct distutils recipe

### DIFF
--- a/recipes-txt/pcr-calc/pcr-calc_git.bb
+++ b/recipes-txt/pcr-calc/pcr-calc_git.bb
@@ -16,4 +16,4 @@ SRC_URI += " \
 "
 SRCREV = "master"
 
-inherit autotools distutils-base
+inherit autotools distutils-common-base


### PR DESCRIPTION
While attempting to build nilrt I noticed distutils-base does not exist, but distutils-common-base does. 