### PR TITLE
pcr-calc: Replace distutils-base with distutils3-base.

### DIFF
--- a/recipes-txt/pcr-calc/pcr-calc_git.bb
+++ b/recipes-txt/pcr-calc/pcr-calc_git.bb
@@ -16,4 +16,4 @@ SRC_URI += " \
 "
 SRCREV = "master"
 
-inherit autotools distutils-base
+inherit autotools distutils3-base


### PR DESCRIPTION
distutils-base was replaced by distutils3-base to support Python3
in Dunfell.

