### PR TITLE
Add Strongswan 5.6+ support

### DIFF
--- a/networking-layer/recipes-support/strongswan/strongswan_5.%.bbappend
+++ b/networking-layer/recipes-support/strongswan/strongswan_5.%.bbappend
@@ -8,8 +8,8 @@ PACKAGECONFIG += " \
     imv-os \
     imc-attestation \
     imv-attestation \
-    imc-swid \
-    imv-swid \
+    imc-swima \
+    imv-swima \
     tnc-ifmap \
     tnc-imc \
     tnc-imv \
@@ -28,7 +28,8 @@ PACKAGECONFIG[imc-os] = "--enable-imc-os,--disable-imc-os,,"
 PACKAGECONFIG[imv-os] = "--enable-imv-os,--disable-imv-os,,"
 PACKAGECONFIG[imc-attestation] = "--enable-imc-attestation,--disable-imc-attestation,,"
 PACKAGECONFIG[imv-attestation] = "--enable-imv-attestation,--disable-imv-attestation,,"
-PACKAGECONFIG[imc-swid] = "--enable-imc-swid,--disable-imc-swid,,"
+PACKAGECONFIG[imc-swima] = "--enable-imc-swima,--disable-imc-swima,json-c,"
+PACKAGECONFIG[imv-swima] = "--enable-imv-swima,--disable-imv-swima,json-c,"
 PACKAGECONFIG[tnc-ifmap] = "--enable-tnc-ifmap,--disable-tnc-ifmap,libxml2,"
 PACKAGECONFIG[tnc-imc] = "--enable-tnc-imc,--disable-tnc-imc,,"
 PACKAGECONFIG[tnc-imv] = "--enable-tnc-imv,--disable-tnc-imv,,"

--- a/networking-layer/recipes-support/strongswan/strongswan_5.%.bbappend
+++ b/networking-layer/recipes-support/strongswan/strongswan_5.%.bbappend
@@ -36,7 +36,7 @@ PACKAGECONFIG[tnc-pdp] = "--enable-tnc-pdp,--disable-tnc-pdp,,"
 PACKAGECONFIG[tnccs-11] = "--enable-tnccs-11,--disable-tnccs-11,libxml2,"
 PACKAGECONFIG[tnccs-20] = "--enable-tnccs-20,--disable-tnccs-20,,"
 PACKAGECONFIG[tnccs-dynamic] = "--enable-tnccs-dynamic,--disable-tnccs-dynamic,,"
-PACKAGECONFIG[tss-trousers] = "--with-tss=trousers,,libtspi,"
+PACKAGECONFIG[tss-trousers] = "--enable-tss-trousers,,libtspi,"
 
 FILES_${PN} += "${libdir}/ipsec/imcvs/*.so ${datadir}/regid.2004-03.org.strongswan"
 FILES_${PN}-dbg += "${libdir}/ipsec/imcvs/.debug"


### PR DESCRIPTION
meta-measured strongswan bbappend has been broken since sumo moved to version 5.5.

Fix the incompatible options.