### PR TITLE
GitHub has deprecated the git fetch protocol causing all git://

### DIFF
--- a/recipes-tpm/tpm2-abrmd/tpm2-abrmd_git.bb
+++ b/recipes-tpm/tpm2-abrmd/tpm2-abrmd_git.bb
@@ -2,7 +2,7 @@ include ${BPN}.inc
 
 DEFAULT_PREFERENCE = "-1"
 
-SRC_URI += "git://github.com/01org/tpm2-abrmd;protocol=git;branch=master;name=tpm2-abrmd;destsuffix=tpm2-abrmd"
+SRC_URI += "git://github.com/01org/tpm2-abrmd;protocol=https;branch=master;name=tpm2-abrmd;destsuffix=tpm2-abrmd"
 
 # https://lists.yoctoproject.org/pipermail/yocto/2013-November/017042.html
 SRCREV = "${AUTOREV}"

--- a/recipes-tpm/tpm2-tools/tpm2-tools_git.bb
+++ b/recipes-tpm/tpm2-tools/tpm2-tools_git.bb
@@ -5,7 +5,7 @@ DEFAULT_PREFERENCE = "-1"
 BRANCH = "master"
 
 SRC_URI = " \
-    git://github.com/tpm2-software/tpm2-tools.git;branch=${BRANCH} \
+    git://github.com/tpm2-software/tpm2-tools.git;branch=${BRANCH};protocol=https \
     "
 
 S = "${WORKDIR}/git"

--- a/recipes-tpm/tpm2-tss/tpm2-tss_git.bb
+++ b/recipes-tpm/tpm2-tss/tpm2-tss_git.bb
@@ -2,7 +2,7 @@ include ${BPN}.inc
 
 DEFAULT_PREFERENCE = "-1"
 
-SRC_URI = "git://github.com/tpm2-software/${BPN}.git;protocol=git;branch=master;name=${BPN};destsuffix=${BPN}"
+SRC_URI = "git://github.com/tpm2-software/${BPN}.git;protocol=https;branch=master;name=${BPN};destsuffix=${BPN}"
 
 S = "${WORKDIR}/${BPN}"
 


### PR DESCRIPTION
fetches that use the git protocol to fail.
https://github.blog/2021-09-01-improving-git-protocol-security-github/

Verified that a build with this layer does not error on parsing.

Signed-off-by: James Minor <james.minor@ni.com>